### PR TITLE
Silence Azure cmdlet output in demo script

### DIFF
--- a/go.ps1
+++ b/go.ps1
@@ -1,3 +1,5 @@
+$VerbosePreference = 'SilentlyContinue'
+
 $Tenant = "8c781dba-1521-44e4-9886-e37f91a6f736"
 $SubID = "ef17a603-a390-49bd-946c-cc18aa67f388"
 # $PaygoSubID = "af86d54a-4949-4bb5-997d-9dd0f288655a"
@@ -8,16 +10,15 @@ if ([string]::IsNullOrEmpty($(Get-AzContext).Account)) {Connect-AzAccount -Tenan
 
 Set-AzContext -Subscription $SubID
 
-New-AzResourceGroup -Name $rgName -Location $Location -verbose
-New-AzResourceGroupDeployment `
--ResourceGroupName $rgName `
--TemplateURI ./deploy.json `
--TemplateParameterFile ./deployparam.json `
--Verbose
+$null = New-AzResourceGroup -Name $rgName -Location $Location
+$null = New-AzResourceGroupDeployment `
+    -ResourceGroupName $rgName `
+    -TemplateURI ./deploy.json `
+    -TemplateParameterFile ./deployparam.json
 
 read-host "Press enter to cleanup the demo"
-Remove-AzResourceGroup -Name NetworkWatcherRG -Force -verbose
-Remove-AzResourceGroup -Name $rgName -Force -verbose
+$null = Remove-AzResourceGroup -Name NetworkWatcherRG -Force
+$null = Remove-AzResourceGroup -Name $rgName -Force
 
 
 


### PR DESCRIPTION
## Summary
- stop emitting verbose output by removing explicit `-Verbose` flags from the provisioning and cleanup commands
- discard command return objects so the Azure PowerShell cmdlets no longer print their default tables while the demo runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e390eb726c8320815293497ce052f0